### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "phat/setup"]
 	path = phat/setup
-	url = git@github.com:shelvenzhou/phala-blockchain-setup.git
+	url = https://github.com/shelvenzhou/phala-blockchain-setup.git


### PR DESCRIPTION
Update .gitmodule to fix a CI problem: https://github.com/Phala-Network/index-contract/issues/21

Github CI fails to checkout submodules specified with git protocol. Had tried to setup env variable `CARGO_NET_GIT_FETCH_WITH_CLI=true`,  ended up with [permission denial error](https://github.com/tenheadedlion/index-contract/actions/runs/3748094779/jobs/6365043023#step:6:43)

The solution to the problem is simply to change git protocol to https. Checkout [this result output](https://github.com/tenheadedlion/index-contract/actions/runs/3748192332/jobs/6365250915#step:6:24) for detail



