### PR TITLE
Fix sub rollup storage key calculation

### DIFF
--- a/phat/Cargo.lock
+++ b/phat/Cargo.lock
@@ -1763,9 +1763,9 @@ checksum = "3da595e670ee22ac5ae563a55388ce2148d68b993fe09ca0099a247cb55cf790"
 
 [[package]]
 name = "pink-subrpc"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4d515824efb66f1d5433368501c2d7e617131f387d244c7274070811d9e1cd"
+checksum = "ada84ef47e0fd6b10e0fdee583ed731161a578ee8e2a59e8431802a3fd86b559"
 dependencies = [
  "base58",
  "hex",

--- a/phat/contracts/sub_price_feed/Cargo.toml
+++ b/phat/contracts/sub_price_feed/Cargo.toml
@@ -21,7 +21,7 @@ pink-json = { git = "https://github.com/Phala-Network/pink-json.git", branch = "
 
 phat_offchain_rollup = { path = "../../crates/rollup", default-features = false, features = ["substrate"] }
 
-subrpc = { package = "pink-subrpc", version = "0.4.1", default-features = false }
+subrpc = { package = "pink-subrpc", version = "0.4.2", default-features = false }
 hex = { version = "0.4", default-features = false }
 
 [dev-dependencies]

--- a/phat/crates/rollup/Cargo.toml
+++ b/phat/crates/rollup/Cargo.toml
@@ -26,7 +26,7 @@ ethabi = { version = "18.0.0", default-features = false, features = [
 ], optional = true }
 
 # for Substrate rollup
-subrpc = { package = "pink-subrpc", version = "0.4.1", default-features = false, optional = true }
+subrpc = { package = "pink-subrpc", version = "0.4.2", default-features = false, optional = true }
 
 [features]
 default = ["std", "logging"]

--- a/phat/crates/rollup/src/clients/substrate.rs
+++ b/phat/crates/rollup/src/clients/substrate.rs
@@ -39,8 +39,8 @@ impl<'a> KvSnapshot for SubstrateSnapshot<'a> {
         let key1: &[u8] = self.contract_id.as_ref();
         let key2: &[u8] = &key.to_owned().encode();
         let storage_key = subrpc::storage::storage_double_map_prefix::<
-            subrpc::hasher::Blake2_128,
-            subrpc::hasher::Blake2_128,
+            subrpc::hasher::Blake2_128Concat,
+            subrpc::hasher::Blake2_128Concat,
         >(&prefix, key1, key2);
         let value = subrpc::get_storage(self.rpc, &storage_key, None)
             .log_err("rollup snapshot: get storage failed")
@@ -221,7 +221,7 @@ pub fn get_name_owner(rpc: &str, contract_id: &AccountId) -> Result<Option<Accou
     let prefix = subrpc::storage::storage_prefix("PhatRollupAnchor", "SubmitterByNames");
     let map_key: &[u8] = contract_id.as_ref();
     let storage_key =
-        subrpc::storage::storage_map_prefix::<subrpc::hasher::Blake2_128>(&prefix, map_key);
+        subrpc::storage::storage_map_prefix::<subrpc::hasher::Blake2_128Concat>(&prefix, map_key);
     // Get storage
     let value = subrpc::get_storage(rpc, &storage_key, None).or(Err(Error::FailedToGetStorage))?;
     if let Some(value) = value {


### PR DESCRIPTION
This PR is going to fix the storage key hash function we use to fetch off-chain pallet storage data, e.g. change `Blake2_128` to `Blake2_128Concat`. As we fixed the storage key calculation on pink-subrpc 0.4.2, if hash function we use is not correct, the data query will fail.